### PR TITLE
Add new methods to guard against null/empty/white-space strings.

### DIFF
--- a/src/LiteGuard/Guard.cs
+++ b/src/LiteGuard/Guard.cs
@@ -113,6 +113,60 @@ namespace LiteGuard
             }
         }
 
+        /// <summary>
+        /// Guards against an empty string.
+        /// </summary>
+        /// <param name="parameterName">Name of the parameter.</param>
+        /// <param name="argument">The string to check</param>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is the empty string.</exception>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Source package.")]
+        [DebuggerStepThrough]
+        public static void AgainstEmptyString(string parameterName, string argument)
+        {
+            if (argument == string.Empty)
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0} is an empty string.", parameterName),
+                    parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Guards against a null or empty string.
+        /// </summary>
+        /// <param name="parameterName">Name of the parameter.</param>
+        /// <param name="argument">The string to check</param>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is the empty string.</exception>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Source package.")]
+        [DebuggerStepThrough]
+        public static void AgainstNullOrEmptyString(string parameterName, string argument)
+        {
+            AgainstNullArgument(parameterName, argument);
+            AgainstEmptyString(parameterName, argument);
+        }
+
+        /// <summary>
+        /// Guards against a null, empty, or white-space string.
+        /// </summary>
+        /// <param name="parameterName">Name of the parameter.</param>
+        /// <param name="argument">The string to check</param>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is empty or consists only of white-space characters.</exception>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Source package.")]
+        [DebuggerStepThrough]
+        public static void AgainstNullOrWhiteSpaceString(string parameterName, string argument)
+        {
+            AgainstNullArgument(parameterName, argument);
+
+            if (argument.Trim() == string.Empty)
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0} is an empty or white-space string.", parameterName),
+                    parameterName);
+            }
+        }
+
 #if NETSTANDARD2_0
         /// <summary>
         /// Determines whether the specified type is a nullable type.

--- a/tests/LiteGuardTests/GuardFeature.cs
+++ b/tests/LiteGuardTests/GuardFeature.cs
@@ -249,5 +249,157 @@ namespace LiteGuardTests.Acceptance
             "Then no exception should be thrown"
                 .x(() => Assert.Null(exception));
         }
+
+        [Scenario]
+        public static void NullString(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a null string"
+                .x(() => argument = null);
+
+            "When guarding against a null or empty string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstNullOrEmptyString(parameterName, argument)));
+
+            "Then the exception should be an argument null exception"
+                .x(() => Assert.IsType<ArgumentNullException>(exception));
+
+            "And the exception message should contain the parameter name and \"null\""
+                .x(() =>
+                {
+                    Assert.Contains(parameterName, exception.Message);
+                    Assert.Contains("null", exception.Message);
+                });
+
+            "And the exception parameter name should be the parameter name"
+                .x(() => Assert.Equal(parameterName, ((ArgumentNullException)exception).ParamName));
+        }
+
+        [Scenario]
+        public static void EmptyString(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And an empty string"
+                .x(() => argument = string.Empty);
+
+            "When guarding against an empty string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstEmptyString(parameterName, argument)));
+
+            "Then the exception should be an argument exception"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+
+            "And the exception message should contain the parameter name and \"empty string\""
+                .x(() =>
+                {
+                    Assert.Contains(parameterName, exception.Message);
+                    Assert.Contains("empty string", exception.Message);
+                });
+
+            "And the exception parameter name should be the parameter name"
+                .x(() => Assert.Equal(parameterName, ((ArgumentException)exception).ParamName));
+        }
+
+        [Scenario]
+        public static void NonEmptyNonWhiteSpaceString(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a non-empty string"
+                .x(() => argument = "foobar");
+
+            "When guarding against an empty string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstEmptyString(parameterName, argument)));
+
+            "Then no exception should be thrown"
+                .x(() => Assert.Null(exception));
+        }
+
+        [Scenario]
+        public static void WhiteSpaceString(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a string consisting of white-space characters"
+                .x(() => argument = "   ");
+
+            "When guarding against an empty string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstEmptyString(parameterName, argument)));
+
+            "Then no exception should be thrown"
+                .x(() => Assert.Null(exception));
+        }
+
+        [Scenario]
+        public static void AgainsNullOrWhiteSpaceString_WhiteSpace(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a string consisting of white-space characters"
+                .x(() => argument = "   ");
+
+            "When guarding against a null or white-space string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstNullOrWhiteSpaceString(parameterName, argument)));
+
+            "Then the exception should be an argument exception"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+
+            "And the exception message should contain the parameter name and \"white-space string\""
+                .x(() =>
+                {
+                    Assert.Contains(parameterName, exception.Message);
+                    Assert.Contains("white-space string", exception.Message);
+                });
+
+            "And the exception parameter name should be the parameter name"
+                .x(() => Assert.Equal(parameterName, ((ArgumentException)exception).ParamName));
+        }
+
+        [Scenario]
+        public static void AgainsNullOrWhiteSpaceString_Null(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a null string"
+                .x(() => argument = null);
+
+            "When guarding against a null or white-space string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstNullOrWhiteSpaceString(parameterName, argument)));
+
+            "Then the exception should be an argument null exception"
+                .x(() => Assert.IsType<ArgumentNullException>(exception));
+
+            "And the exception message should contain the parameter name and \"null\""
+                .x(() =>
+                {
+                    Assert.Contains(parameterName, exception.Message);
+                    Assert.Contains("null", exception.Message);
+                });
+
+            "And the exception parameter name should be the parameter name"
+                .x(() => Assert.Equal(parameterName, ((ArgumentNullException)exception).ParamName));
+        }
+
+        [Scenario]
+        public static void AgainsNullOrWhiteSpaceString_ValidString(string parameterName, string argument, Exception exception)
+        {
+            "Given a parameter name"
+                .x(() => parameterName = "foo");
+
+            "And a valid string"
+                .x(() => argument = "foobaz");
+
+            "When guarding against a null or white-space string"
+                .x(() => exception = Record.Exception(() => Guard.AgainstNullOrWhiteSpaceString(parameterName, argument)));
+
+            "Then no exception should be thrown"
+                .x(() => Assert.Null(exception));
+        }
     }
 }


### PR DESCRIPTION
I often do checks like this:

```csharp
void SomeMethod(string foo)
{
    if (foo == null)
    {
         throw new ArgumentNullException();
    }
    
    if (foo.Trim() == string.Empty)
    {
         throw new ArgumentException("Parameter should not be empty.");
    } 
}
```

Some people like to use  `string.IsNullOrEmpty` or `string.IsNullOrWhiteSpace` and then throw a `ArgumentNullException`, but that bothers me, since an empty string is not null.

So, I figure it'd make sense to add some more methods here to check for those cases.

One more note. The name of the `AgainstNullOrWhiteSpaceString` method is slightly misleading, since it will also throw for empty string. I tried to keep the semantics of the `string.IsNullOrWhiteSpace` method:

```csharp
string.IsNullOrEmpty(string.Empty) // true
string.IsNullOrEmpty("   ") // false
string.IsNullOrWhiteSpace("   ") // true
string.IsNullOrWhiteSpace(string.Empty) // also true
```


