### PR TITLE
remove redundant IsTestProject property

### DIFF
--- a/src/LiteGuard/LiteGuard.csproj
+++ b/src/LiteGuard/LiteGuard.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IsTestProject>false</IsTestProject>
     <LangVersion>3</LangVersion>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/targets/Targets.csproj
+++ b/targets/Targets.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/tests/LiteGuardTests/LiteGuardTests.csproj
+++ b/tests/LiteGuardTests/LiteGuardTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
This was added to remove this annoying message in anticipation of https://github.com/Microsoft/vstest/issues/1866:

> Skipping running test for project {project file}. To run tests with dotnet test add "true" property to project file.

But this is not the right solution. The log level for that message should be reduced, as per https://github.com/Microsoft/vstest/pull/1867/files#r244541222

For test projects, there is no need to set this property to `true`, since that is done by `Microsoft.NET.Test.Sdk`.